### PR TITLE
 (maint) Add install helpers for pe-client-tools

### DIFF
--- a/lib/beaker-pe.rb
+++ b/lib/beaker-pe.rb
@@ -10,8 +10,8 @@ module Beaker
   module DSL
     module PE
       include Beaker::DSL::InstallUtils::PEUtils
+      include Beaker::DSL::InstallUtils::PEClientTools
       include Beaker::Options::PEVersionScraper
-      include Beaker::DSL::PEClientTools::InstallHelper
       include Beaker::DSL::PEClientTools::ConfigFileHelper
       include Beaker::DSL::PEClientTools::ExecutableHelper
     end

--- a/lib/beaker-pe/pe-client-tools/install_helper.rb
+++ b/lib/beaker-pe/pe-client-tools/install_helper.rb
@@ -1,9 +1,108 @@
 module Beaker
   module DSL
-    module PEClientTools
-      module InstallHelper
+    module InstallUtils
+      module PEClientTools
 
-        include Beaker::DSL::InstallUtils::WindowsUtils
+        def install_pe_client_tools_on(hosts, opts = {})
+          # FIXME: accomodate production released location(s)
+          #{{{
+          product = 'pe-client-tools'
+          opts = {
+            :puppet_collection       => 'PC1',
+            :pe_client_tools_sha     => ENV['SHA'],
+            :pe_client_tools_version => ENV['SUITE_VERSION'] || ENV['SHA']
+          }
+          urls = { :dev_builds_url   => "http://builds.delivery.puppetlabs.net",
+          }
+
+          opts = urls.merge(opts)
+
+          block_on hosts do |host|
+            package_name = nil
+            variant, version, arch, codename = host['platform'].to_array
+            case host['platform']
+            when /el-|fedora|sles|centos|cisco_/
+              release_path = "#{opts[:dev_builds_url]}/#{product}/#{ opts[:pe_client_tools_sha] }/artifacts/#{variant}/#{version}/#{opts[:puppet_collection]}/#{arch}"
+              package_name = product.dup
+              package_name << "-#{opts[:pe_client_tools_version]}-1.#{variant}#{version}.#{arch}.rpm" if opts[:pe_client_tools_version]
+            when /debian|ubuntu|cumulus|huaweios/
+              release_path = "#{opts[:dev_builds_url]}/#{product}/#{ opts[:pe_client_tools_sha] }/artifacts/deb/#{codename}/#{opts[:puppet_collection]}"
+              package_name = product.dup
+              package_name << "_#{opts[:pe_client_tools_version]}-1#{host['platform'].codename}_#{arch}.deb" if opts[:pe_client_tools_version]
+            when /windows/
+              release_path = "#{opts[:dev_builds_url]}/#{product}/#{ opts[:pe_client_tools_sha] }/artifacts/#{variant}/#{opts[:puppet_collection]}/x#{arch}"
+              package_name = product.dup
+              package_name << "-#{opts[:pe_client_tools_version]}.1-x#{arch}_VANAGON.msi" if opts[:pe_client_tools_version]
+            when /osx/
+              release_path = "#{opts[:dev_builds_url]}/#{product}/#{ opts[:pe_client_tools_sha] }/artifacts/apple/#{version}/#{opts[:puppet_collection]}/#{arch}"
+              package_base = product.dup
+              package_base << "-#{opts[:pe_client_tools_version]}" if opts[:pe_client_tools_version]
+              package_name = package_base.dup
+              package_name << '-1' if opts[:pe_client_tools_version]
+              installer    = package_name + '-installer.pkg'
+              package_name << ".#{variant}#{version}.dmg" if opts[:pe_client_tools_version]
+            else
+              raise "install_puppet_agent_on() called for unsupported " +
+                "platform '#{host['platform']}' on '#{host.name}'"
+            end
+
+            if package_name
+              case host['platform']
+              when /windows/
+                install_msi_on(host, File.join(release_path, package_name), {}, opts)
+              else
+                copy_dir_local = File.join('tmp', 'repo_configs')
+                fetch_http_file(release_path, package_name, copy_dir_local)
+                scp_to host, File.join(copy_dir_local, package_name), host.external_copy_base
+
+                if host['platform'] =~ /debian|ubuntu|cumulus|huaweios/
+                  on host, "dpkg -i #{package_name}"
+                elsif host['platform'] =~ /osx/
+                  install_dmg_on(host, package_name, package_base, installer, opts)
+                else
+                  host.install_package( package_name )
+                end
+              end
+            end
+          end
+          #}}}
+        end
+
+        def install_dmg_on(host, dmg_path, pkg_base, pkg_name, opts = {})
+          dmg_name = File.basename(dmg_path, '.dmg')
+          on(host, "hdiutil attach #{dmg_name}.dmg")
+          on(host, "installer -pkg /Volumes/#{pkg_base}/#{pkg_name} -target /")
+        end
+
+        def install_msi_on(hosts, msi_path, msi_opts = {}, opts = {})
+          #{{{
+          block_on hosts do | host |
+            msi_opts['PUPPET_AGENT_STARTUP_MODE'] ||= 'Manual'
+            batch_path, log_file = create_install_msi_batch_on(host, msi_path, msi_opts)
+
+            # begin / rescue here so that we can reuse existing error msg propagation
+            begin
+              # 1641 = ERROR_SUCCESS_REBOOT_INITIATED
+              # 3010 = ERROR_SUCCESS_REBOOT_REQUIRED
+              on host, Command.new("\"#{batch_path}\"", [], { :cmdexe => true }), :acceptable_exit_codes => [0, 1641, 3010]
+            rescue
+              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
+              raise
+            end
+
+            if opts[:debug]
+              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
+            end
+
+            if !host.is_cygwin?
+              # HACK: for some reason, post install we need to refresh the connection to make puppet available for execution
+              host.close
+            end
+
+          end
+          #}}}
+        end
+
       end
     end
   end


### PR DESCRIPTION
This commit adds three helper methods to install pe-client-tools on Windows.

The first is a general  method that is designed to abstract
away the installation of pe-client-tools on supported operating systems.
Currently, it only accommodates development builds of the tools based on the
provided SHA and SUITE_VERSION environment variables available.

The second is a generic method to install an msi package on a target host.
Beaker's built in method of this name assumes that msi installed involves the
installation of puppet, so this method overrides that one without such an
assumption.

The this is a generic method to install a dmg package on a target host.
Beaker's built in `install_package` method for osx does not accommodate for an
installer `pkg` file that is named differently from the containing `dmg`. This
method forces the user to supply both names explicitly.
